### PR TITLE
Improvements

### DIFF
--- a/udev.go
+++ b/udev.go
@@ -181,7 +181,7 @@ func (m *Monitor) ReceiveDevice() *Device {
 }
 
 func (m *Monitor) AddFilter(subsystem string, devtype string) error {
-	err := nil
+	var err error
 	if len(devtype) == 0 {
 		err := C.udev_monitor_filter_add_match_subsystem_devtype(m.ptr, C.CString(subsystem), nil)
 	} else {

--- a/udev.go
+++ b/udev.go
@@ -47,15 +47,7 @@ func NewUdev() *Udev {
 // func (u Udev) SetLogger() {
 // 	C.udev_set_log_fn(u.ptr)
 // }
-/*
-func (u *Udev) GetLogPriority() int {
-	return int(C.udev_get_log_priority(u.ptr))
-}
 
-func (u *Udev) SetLogPriority(priority int) {
-	C.udev_set_log_priority(u.ptr, C.int(priority))
-}
-*/
 func (u *Udev) GetUserdata() unsafe.Pointer {
 	return C.udev_get_userdata(u.ptr)
 }

--- a/udev.go
+++ b/udev.go
@@ -47,7 +47,7 @@ func NewUdev() *Udev {
 // func (u Udev) SetLogger() {
 // 	C.udev_set_log_fn(u.ptr)
 // }
-
+/*
 func (u *Udev) GetLogPriority() int {
 	return int(C.udev_get_log_priority(u.ptr))
 }
@@ -55,7 +55,7 @@ func (u *Udev) GetLogPriority() int {
 func (u *Udev) SetLogPriority(priority int) {
 	C.udev_set_log_priority(u.ptr, C.int(priority))
 }
-
+*/
 func (u *Udev) GetUserdata() unsafe.Pointer {
 	return C.udev_get_userdata(u.ptr)
 }
@@ -181,7 +181,12 @@ func (m *Monitor) ReceiveDevice() *Device {
 }
 
 func (m *Monitor) AddFilter(subsystem string, devtype string) error {
-	err := C.udev_monitor_filter_add_match_subsystem_devtype(m.ptr, C.CString(subsystem), C.CString(devtype))
+	err := nil
+	if len(devtype) == 0 {
+		err := C.udev_monitor_filter_add_match_subsystem_devtype(m.ptr, C.CString(subsystem), nil)
+	} else {
+		err := C.udev_monitor_filter_add_match_subsystem_devtype(m.ptr, C.CString(subsystem), C.CString(devtype))
+	}
 	if err == 0 {
 		return nil
 	}

--- a/udev.go
+++ b/udev.go
@@ -181,11 +181,11 @@ func (m *Monitor) ReceiveDevice() *Device {
 }
 
 func (m *Monitor) AddFilter(subsystem string, devtype string) error {
-	var err error
+	var err C.int
 	if len(devtype) == 0 {
-		err := C.udev_monitor_filter_add_match_subsystem_devtype(m.ptr, C.CString(subsystem), nil)
+		err = C.udev_monitor_filter_add_match_subsystem_devtype(m.ptr, C.CString(subsystem), nil)
 	} else {
-		err := C.udev_monitor_filter_add_match_subsystem_devtype(m.ptr, C.CString(subsystem), C.CString(devtype))
+		err = C.udev_monitor_filter_add_match_subsystem_devtype(m.ptr, C.CString(subsystem), C.CString(devtype))
 	}
 	if err == 0 {
 		return nil


### PR DESCRIPTION
- Removed "udev_get_log_priority" since they are deprecated in udev latest library.
- Monitor.AddFilter() can accept empty string as Device Type.
